### PR TITLE
force a space after the url

### DIFF
--- a/web/static/js/views/game/show.js
+++ b/web/static/js/views/game/show.js
@@ -79,7 +79,7 @@ class GameShowView extends React.Component {
         </header>
         <ol className="instructions">
           <li>Copy this link <input onClick={handleGameLinkClick} defaultValue={url} readOnly={true}/>
-            by clicking on it and share it with your opponent.                                                            </li>
+          &nbsp;by clicking on it and share it with your opponent.</li>
           <li>To place a ship in your board select one by clicking on the gray boxes.</li>
           <li>The selected ship will turn green.</li>
           <li>Switch the orientation of the ship by clicking again on it.</li>


### PR DESCRIPTION
In step 1 of the instructions the lack of a space after the URL bugged me:

![2016-04-22 09_56_57-ahoy matey welcome to phoenix battleship](https://cloud.githubusercontent.com/assets/658935/14727680/a729f196-0870-11e6-8f50-aca273244b8b.png)

I added an &nbsp; to force a space after the url. There's probably a more hip and happening way to do this... but I'm old school.
