### PR TITLE
Resolve build warnings

### DIFF
--- a/lib/battleship/game.ex
+++ b/lib/battleship/game.ex
@@ -88,9 +88,11 @@ defmodule Battleship.Game do
 
     opponent_id = get_opponents_id(game, player_id)
 
-    if opponent_id != nil do
-      game_data = Map.put(game_data, :opponents_board, Board.get_opponents_data(opponent_id))
-    end
+    game_data =
+      case opponent_id do
+        nil -> game_data
+        _   -> Map.put(game_data, :opponents_board, Board.get_opponents_data(opponent_id))
+      end
 
     {:reply, game_data, game}
   end


### PR DESCRIPTION
Resolving warnings about unsafe variable when compiling

```
==> battleship
Compiling 20 files (.ex)
warning: the variable "game_data" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/battleship/game.ex:95
```
